### PR TITLE
Fix faulty background-size CSS style

### DIFF
--- a/assets/styles/tailwind.css
+++ b/assets/styles/tailwind.css
@@ -1163,7 +1163,7 @@ video {
 }
 
 .bg-full {
-  background-size: 100$;
+  background-size: 100%;
 }
 
 .border-collapse {


### PR DESCRIPTION
I think there's a typo in the CSS file that makes the file an invalid `.css` sheet.

This PR just changes `$` to `%`.